### PR TITLE
implemented basic list tables endpoint for #1

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -6,6 +6,8 @@ import (
 	_ "github.com/tursodatabase/libsql-client-go/libsql"
 )
 
+var MaxPageSize = 100
+
 func New(dsn string) (*sql.DB, error) {
 	db, err := sql.Open("libsql", dsn)
 

--- a/internal/db/scanner.go
+++ b/internal/db/scanner.go
@@ -1,6 +1,6 @@
 package db
 
-// ColScanner is an interface used by MapScan and SliceScan
+// ColScanner is an interface used by MapScan
 type ColScanner interface {
 	Columns() ([]string, error)
 	Scan(dest ...interface{}) error

--- a/internal/server/response.go
+++ b/internal/server/response.go
@@ -1,0 +1,5 @@
+package server
+
+type Response struct {
+	Items interface{} `json:"items"`
+}


### PR DESCRIPTION
Adds implementation for basic endpoint to list tables. I have left out pagination for now as I want to get out all MVP endpoints, then figure out a pattern to add pagination to any query.